### PR TITLE
test: retry the provider manifest apply in the version-pairing bootstrap

### DIFF
--- a/test/certification/suites/version-pairing/suite_test.go
+++ b/test/certification/suites/version-pairing/suite_test.go
@@ -177,11 +177,16 @@ func deployCAPIOperator(config *clusterctl.E2EConfig, proxy capiframework.Cluste
 // applyProviderTemplate renders an envsubst provider manifest (${CAPI_VERSION},
 // ${CAPHV_VERSION}, ${CAPHV_COMPONENTS_URL} come from the e2e config variables
 // exported to the environment) and applies it to the management cluster.
+// The apply retries: the operator chart install waits for the Deployment to be
+// Available, but its admission webhook endpoint can lag behind by a few
+// seconds (connection refused), especially on slow CI runners.
 func applyProviderTemplate(proxy capiframework.ClusterProxy, template []byte) {
-	Expect(turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
-		Proxy:    proxy,
-		Template: template,
-	})).To(Succeed(), "Failed to apply provider manifest")
+	Eventually(func() error {
+		return turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
+			Proxy:    proxy,
+			Template: template,
+		})
+	}, "2m", "10s").Should(Succeed(), "Failed to apply provider manifest")
 }
 
 // waitForProviderReady blocks until the given cluster-api-operator provider reports


### PR DESCRIPTION
The nightly `certification` run of Aug 9 failed in the BeforeSuite: applying the CAPHV `InfrastructureProvider` hit the cluster-api-operator admission webhook while its endpoint was not serving yet (`failed calling webhook ... capi-operator-webhook-service`), a few seconds after the RKE2 providers applied fine. The operator chart install waits for the Deployment to be Available, but the webhook endpoint can lag behind, especially on slow CI runners; the identical code passed the night before and the rerun confirms the flake.

Retry the apply for up to two minutes, matching how the suite already treats every other eventually-consistent step.